### PR TITLE
修复关闭buffer pool 与访问double write buffer 冲突的问题

### DIFF
--- a/benchmark/record_manager_concurrency_test.cpp
+++ b/benchmark/record_manager_concurrency_test.cpp
@@ -121,6 +121,9 @@ public:
     }
 
     handler_.close();
+    // TODO 很怪，引入double write buffer后，必须要求先close buffer pool，再执行bpm.close_file。
+    // 以后必须修理好bpm、buffer pool、double write buffer之间的关系
+    buffer_pool_->close_file();
     bpm.close_file(this->record_filename().c_str());
     buffer_pool_ = nullptr;
     LOG_INFO("test %s teardown done. threads=%d, thread index=%d",
@@ -135,7 +138,7 @@ public:
     RID             rid;
     TestRecord      record;
     vector<int32_t> record_values;
-    record_values.reserve(max - min);
+//    record_values.reserve(max - min);
     for (int32_t value = min; value < max; ++value) {
       record_values.push_back(value);
     }
@@ -158,7 +161,7 @@ public:
   {
     int32_t max = static_cast<int32_t>(state.range(0) * 3);
     if (max <= 0) {
-      max = INT32_MAX - 1;
+      max = INT32_MAX / 2 - 1;
     }
     return max;
   }

--- a/src/observer/storage/buffer/disk_buffer_pool.cpp
+++ b/src/observer/storage/buffer/disk_buffer_pool.cpp
@@ -273,6 +273,12 @@ RC DiskBufferPool::close_file()
     return rc;
   }
 
+  rc = dblwr_manager_.clear_pages(this);
+  if (OB_FAIL(rc)) {
+    LOG_WARN("failed to clear pages in double write buffer. filename=%s, rc=%s", file_name_.c_str(), strrc(rc));
+    return rc;
+  }
+
   disposed_pages_.clear();
 
   if (close(file_desc_) < 0) {
@@ -283,6 +289,7 @@ RC DiskBufferPool::close_file()
   file_desc_ = -1;
 
   bp_manager_.close_file(file_name_.c_str());
+
   return RC::SUCCESS;
 }
 
@@ -788,14 +795,16 @@ RC BufferPoolManager::flush_page(Frame &frame)
   return bp->flush_page(frame);
 }
 
-RC BufferPoolManager::get_disk_buffer(const char *file_name, DiskBufferPool **buf)
+DiskBufferPool *BufferPoolManager::get_disk_buffer(const char *file_name)
 {
+  scoped_lock lock_guard(lock_);
 
-  if (buffer_pools_.count(file_name) != 0) {
-    *buf = buffer_pools_[file_name];
+  auto iter = buffer_pools_.find(file_name);
+  if (iter != buffer_pools_.end()) {
+    return iter->second;
   }
 
-  return RC::SUCCESS;
+  return nullptr;
 }
 
 static BufferPoolManager *default_bpm = nullptr;
@@ -813,8 +822,8 @@ DoubleWriteBuffer::DoubleWriteBuffer(BufferPoolManager &bp_manager) : bp_manager
 
 DoubleWriteBuffer::~DoubleWriteBuffer()
 {
-  for (auto page : dblwr_pages_) {
-    delete page;
+  for (auto &pair : dblwr_pages_) {
+    delete pair.second;
   }
   close(file_desc_);
 }
@@ -835,33 +844,12 @@ RC DoubleWriteBuffer::flush_page()
 {
   sync();
 
-  buffers_.clear();
-  for (const auto &page : dblwr_pages_) {
-    if (buffers_.count(page->get_file_name()) != 0) {
-      continue;
-    }
-    DiskBufferPool *disk_buffer = nullptr;
-    const char     *file_name   = page->get_file_name();
-    bp_manager_.get_disk_buffer(file_name, &disk_buffer);
-
-    /**
-     * 如果bpm中没有对应的DiskBufferPool，就创建一个新的DiskBufferPool。
-     * 调用bpm中open_file时，需要申请一个新的frame，而如果此时frame manager已满，需要purge page，会导致无限循环
-     */
-    if (disk_buffer == nullptr) {
-      disk_buffer = new DiskBufferPool(bp_manager_, bp_manager_.get_frame_manager(), *this);
-      disk_buffer->open_file_for_dwb(file_name);
-      buffer_to_delete.push_back(disk_buffer);
-    }
-    buffers_[file_name] = disk_buffer;
-  }
-
-  for (const auto &page : dblwr_pages_) {
-    RC rc = write_page(page);
+  for (const auto &pair : dblwr_pages_) {
+    RC rc = write_page(pair.second);
     if (rc != RC::SUCCESS) {
       return rc;
     }
-    delete page;
+    delete pair.second;
   }
 
   for (const auto &buffer : buffer_to_delete) {
@@ -870,8 +858,6 @@ RC DoubleWriteBuffer::flush_page()
   }
 
   dblwr_pages_.clear();
-  pages_.clear();
-  buffers_.clear();
   buffer_to_delete.clear();
 
   return RC::SUCCESS;
@@ -880,10 +866,11 @@ RC DoubleWriteBuffer::flush_page()
 RC DoubleWriteBuffer::add_page(const std::string &file_name, Page &page)
 {
   std::scoped_lock lock_guard(lock_);
-  string           key = file_name + to_string(page.page_num);
 
-  if (pages_.count(key) != 0) {
-    pages_.at(key)->get_page() = page;
+  DoubleWritePageKey key{file_name, page.page_num};
+  auto iter = dblwr_pages_.find(key);
+  if (iter != dblwr_pages_.end()) {
+    iter->second->get_page() = page;
     return RC::SUCCESS;
   }
 
@@ -897,7 +884,7 @@ RC DoubleWriteBuffer::add_page(const std::string &file_name, Page &page)
 
   int64_t          page_cnt   = dblwr_pages_.size();
   DoubleWritePage *dblwr_page = new DoubleWritePage((int)dblwr_pages_.size(), file_name, page);
-  dblwr_pages_.push_back(dblwr_page);
+  dblwr_pages_.insert(std::pair<DoubleWritePageKey, DoubleWritePage *>(key, dblwr_page));
 
   int64_t offset = page_cnt * sizeof(DoubleWritePage);
   if (lseek(file_desc_, offset, SEEK_SET) == -1) {
@@ -910,19 +897,48 @@ RC DoubleWriteBuffer::add_page(const std::string &file_name, Page &page)
     return RC::IOERR_WRITE;
   }
 
-  pages_[key] = dblwr_page;
+  return RC::SUCCESS;
+}
+
+RC DoubleWriteBuffer::clear_pages(DiskBufferPool *buffer_pool)
+{
+  vector<DoubleWritePage *> spec_pages;
+  
+  auto remove_pred = [&spec_pages, buffer_pool](const pair<DoubleWritePageKey, DoubleWritePage *> &pair) {
+    DoubleWritePage *dbl_page = pair.second;
+    if (0 == strcmp(buffer_pool->filename(), dbl_page->get_file_name())) {
+      spec_pages.push_back(dbl_page);
+      return true;
+    }
+    return false;
+  };
+
+  lock_.lock();
+  erase_if(dblwr_pages_, remove_pred);
+  lock_.unlock();
+
+  LOG_INFO("clear pages in double write buffer. file name=%s, page count=%d",
+           buffer_pool->filename(), spec_pages.size());
+
+  RC rc = RC::SUCCESS;
+  for (DoubleWritePage *dbl_page : spec_pages) {
+    rc = buffer_pool->write_page(dbl_page->get_page());
+    if (OB_FAIL(rc)) {
+      LOG_WARN("Failed to write page %s:%d to disk buffer pool. rc=%s",
+               buffer_pool->filename(), dbl_page->get_page().page_num, strrc(rc));
+      break;
+    }
+  }
+
+  ranges::for_each(spec_pages, [](DoubleWritePage *dbl_page) { delete dbl_page; });
 
   return RC::SUCCESS;
 }
 
 RC DoubleWriteBuffer::write_page(DoubleWritePage *dblwr_page)
 {
-  if (buffers_.count(dblwr_page->get_file_name()) == 0) {
-    LOG_ERROR("can't find disk buffer when write page");
-    return RC::IOERR_WRITE;
-  }
-
-  DiskBufferPool *disk_buffer = buffers_[dblwr_page->get_file_name()];
+  DiskBufferPool *disk_buffer = bp_manager_.get_disk_buffer(dblwr_page->get_file_name());
+  ASSERT(disk_buffer != nullptr, "failed to get disk buffer pool of %s", dblwr_page->get_file_name());
 
   return disk_buffer->write_page(dblwr_page->get_page());
 }
@@ -931,9 +947,10 @@ std::optional<Page> DoubleWriteBuffer::get_page(const std::string &file_name, Pa
 {
   std::scoped_lock lock_guard(lock_);
 
-  string key = file_name + to_string(page_num);
-  if (pages_.count(key) != 0) {
-    return make_optional<Page>(pages_.at(key)->get_page());
+  DoubleWritePageKey key{file_name, page_num};
+  auto iter = dblwr_pages_.find(key);
+  if (iter != dblwr_pages_.end()) {
+    return make_optional<Page>(iter->second->get_page());
   }
 
   return std::nullopt;

--- a/src/observer/storage/buffer/disk_buffer_pool.h
+++ b/src/observer/storage/buffer/disk_buffer_pool.h
@@ -260,12 +260,14 @@ public:
   RC recover_page(PageNum page_num);
 
   /**
-   * 刷新页面到磁盘
+   * 刷新页面到磁盘。直接将页面写入磁盘
    */
   RC write_page(Page &page);
 
   RC open_file_for_dwb(const char *file_name);
   RC close_file_for_dwb();
+
+  const char *filename() const { return file_name_.c_str(); }
 
 protected:
   RC allocate_frame(PageNum page_num, Frame **buf);
@@ -319,7 +321,8 @@ public:
   RC close_file(const char *file_name);
 
   RC flush_page(Frame &frame);
-  RC get_disk_buffer(const char *file_name, DiskBufferPool **buf);
+
+  DiskBufferPool *get_disk_buffer(const char *file_name);
 
   BPFrameManager &get_frame_manager() { return frame_manager_; }
 
@@ -355,6 +358,25 @@ private:
   Page page_;
 };
 
+struct DoubleWritePageKey
+{
+  std::string file_name;
+  PageNum     page_num;
+
+  bool operator==(const DoubleWritePageKey &other) const
+  {
+    return file_name == other.file_name && page_num == other.page_num;
+  }
+};
+
+struct DoubleWritePageKeyHash
+{
+  size_t operator()(const DoubleWritePageKey &key) const
+  {
+    return std::hash<std::string>()(key.file_name) ^ std::hash<PageNum>()(key.page_num);
+  }
+};
+
 class DoubleWriteBuffer
 {
 public:
@@ -378,9 +400,9 @@ public:
   RC add_page(const std::string &file_name, Page &page);
 
   /**
-   * 将buffer中的页面写入对应的磁盘
+   * @brief 删除所有与指定文件相关的页面
    */
-  RC write_page(DoubleWritePage *page);
+  RC clear_pages(DiskBufferPool *bp);
 
   /**
    * 查看buffer中是否存在该页面
@@ -388,12 +410,16 @@ public:
   std::optional<Page> get_page(const std::string &file_name, PageNum &page_num);
 
 private:
+  /**
+   * 将buffer中的页面写入对应的磁盘
+   */
+  RC write_page(DoubleWritePage *page);
+
+private:
   int                            file_desc_ = -1;
   common::Mutex                  lock_;
   BufferPoolManager             &bp_manager_;
-  std::vector<DoubleWritePage *> dblwr_pages_;
 
-  std::unordered_map<std::string, DoubleWritePage *> pages_;
-  std::unordered_map<std::string, DiskBufferPool *>  buffers_;
+  std::unordered_map<DoubleWritePageKey, DoubleWritePage *, DoubleWritePageKeyHash> dblwr_pages_;
   std::list<DiskBufferPool *>                        buffer_to_delete;
 };


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem:
在double write buffer刷新页面到磁盘时，页面关联的buffer pool 可能已经关闭了，导致刷新页面失败。

### What is changed and how it works?
在关闭Buffer pool之前，清空所有与它相关的double write buffer pages。

### Other information
代码中有个缺陷，buffer pool manager 、 buffer pool和double write buffer的关系搅合的太紧密。
这个问题后面再改。
